### PR TITLE
Enabling support for pre Clojure-1.3

### DIFF
--- a/control.clj
+++ b/control.clj
@@ -1,0 +1,14 @@
+(use '[control.commands])
+
+(defcluster :lsmaven
+  :user ~(System/getenv "USER")
+  :addresses ["maven.likestream.net"])
+
+
+(deftask :deploy "Deploy jar and pom to maven repo" []
+  (ssh "rm -f /home2/maven/maven2/net/likestream/ring.middleware.logger/0.2.1/ring.middleware.logger-0.2.1.jar" :sudo true)
+  (ssh "rm -f /home2/maven/maven2/net/likestream/ring.middleware.logger/0.2.1/ring.middleware.logger-0.2.1.pom" :sudo true)
+  (ssh "mkdir -p /home2/maven/maven2/net/likestream/ring.middleware.logger/0.2.1" :sudo true)
+  (scp "ring.middleware.logger-0.2.1.jar" "/home2/maven/maven2/net/likestream/ring.middleware.logger/0.2.1" :sudo true)
+  (scp "pom.xml" "/home2/maven/maven2/net/likestream/ring.middleware.logger/0.2.1/ring.middleware.logger-0.2.1.pom" :sudo true)  
+  (ssh "chown -R maven:daemon /home2/maven/maven2/net/likestream/ring.middleware.logger" :sudo true))

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,13 @@
-(defproject ring.middleware.logger "0.2.1"
+(defproject net.likestream/ring.middleware.logger "0.2.1"
   :description "Ring middleware to log each request using Log4J."
-  :plugins [[lein-swank "1.4.4"]]
-  :dependencies [[org.clojure/clojure "1.3.0"]
+
+  :repositories {"mvnrepository" "http://mvnrepository.com/"
+                 "likestream" "http://maven.likestream.net/maven2/"}
+  
+  :dependencies [[org.clojure/clojure "1.2.1"]
                  [org.slf4j/slf4j-log4j12 "1.6.4"]
-                 [log4j "1.2.16"]
+                 [log4j "1.2.17"]
                  [org.clojure/tools.logging "0.2.3"]
                  [clj-logging-config "1.9.6"]
-                 [org.clojars.pjlegato/clansi "1.3.0"]
+                 [net.likestream/clansi "1.2.1"]
                  ])

--- a/src/ring/middleware/logger.clj
+++ b/src/ring/middleware/logger.clj
@@ -48,15 +48,15 @@
 ;;
 ;; TODO: Make a custom layout class that colorizes the log level. Maybe this can be done in a filter.
 ;;
-(def rotating-logger
-  "This logging adapter rotates the logfile nightly at about midnight."
+(def rotating-logger ;; Moved docstring to comment for pre-Clojure 1.3 compatibility
+                     ;; "This logging adapter rotates the logfile nightly at about midnight."
   (DailyRollingFileAppender.
    (EnhancedPatternLayout. production-log-prefix-format)
    base-log-name
    ".yyyy-MM-dd"))
 
-(def appending-logger
-  "This logging adapter simply appends new log lines to the existing logfile."
+(def appending-logger ;; Moved docstring to comment for pre-Clojure 1.3 compatibility
+                      ;;   "This logging adapter simply appends new log lines to the existing logfile."
   (FileAppender.
    (EnhancedPatternLayout. production-log-prefix-format)
    base-log-name
@@ -98,8 +98,8 @@ logger for the application."
 ;; TODO: Alter this subsystem to contain a predefined map of all
 ;; acceptable fg/bg combinations, since some (e.g. white on yellow)
 ;; are practically illegible.
-(def id-colorizations
-  "Foreground / background color codes allowable for random ID colorization."
+(def id-colorizations  ;; Moved docstring to comment for pre-Clojure 1.3 compatibility
+                       ;;   "Foreground / background color codes allowable for random ID colorization."
   {:white :bg-white :black :bg-black :red :bg-red :green :bg-green :blue :bg-blue :yellow :bg-yellow :magenta :bg-magenta :cyan :bg-cyan} )
 
 (def id-foreground-colors (keys id-colorizations))

--- a/src/ring/middleware/logger.clj
+++ b/src/ring/middleware/logger.clj
@@ -18,7 +18,7 @@
   (import (org.apache.log4j DailyRollingFileAppender EnhancedPatternLayout FileAppender)))
 
 ;; TODO: Facilities for easily modifying the default log file name and log level
-(def base-log-name "logs/ring.log")
+(def base-log-name "log/ring.log")
 (def default-log-level :info)
 
 ;; The generation of the calling class, line numbers, etc. is


### PR DESCRIPTION
AFAICT, the use of docstrings in 3? def statement is the only thing preventing earlier Clojure versions from using this code. So, here is a version that moves the docstring out, so I can use this.  Also, I had to specify my forked version of your clansi, which contains exactly the same modification.....
