### PR TITLE
Remove SNAPSHOT from dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage
 
 In your `project.clj`, add the following dependency:
 
-    [ring.middleware.logger "0.5.0-SNAPSHOT"]
+    [ring.middleware.logger "0.5.0"]
 
 
 Then, just add the middleware to your stack. It comes preconfigured with


### PR DESCRIPTION
In clojars, the library is available without the "SNAPSHOT". https://clojars.org/ring.middleware.logger
