### PR TITLE
Clarify docs for custom logger backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ If you'd prefer plaintext logging without the ANSI colors, use
 Custom Logger Backend
 -----------------------
 
-You can supply a custom logger functions to `wrap-with-logger` by supplying
-pairs of `:level custom-logger-fn` as additional arguments.  These will be used
+You can supply custom logger functions to `wrap-with-logger` by supplying pairs
+of `:level custom-logger-fn` as additional arguments.  These will be used
 instead of the default `clojure.tools.logging` functions. The default mapping
 is:
 
@@ -63,8 +63,8 @@ call `wrap-with-logger` like this:
 
 ```clojure
       (wrap-with-logger my-app
-        :info my-info-logger
-        :debug my-debug-logger)
+        :info (fn [x] (my.custom.logging/info x))
+        :debug (fn [x] (my.custom.logging/debug x)))
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ you want to use a different function to log info and debug messages, you could
 call `wrap-with-logger` like this:
 
 ```clojure
-      (wrap-with-logger my-app
+      (wrap-with-logger my-ring-app
         :info (fn [x] (my.custom.logging/info x))
         :debug (fn [x] (my.custom.logging/debug x)))
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ request to whatever logger is in use by clojure.tools.logging.
          {:status 200
           :headers {"Content-Type" "text/html"}
           :body "Hello world!"})
-          
+
     (jetty/run-jetty (logger/wrap-with-logger my-ring-app) {:port 8080})
 
 
@@ -40,17 +40,24 @@ If you'd prefer plaintext logging without the ANSI colors, use
 Custom Logger Backend
 -----------------------
 
-You can supply a map of custom logger functions to `wrap-with-logger`,
-which will be used instead of the default `clojure.tools.logging`
-functions. The default map is:
+You can supply a custom logger functions to `wrap-with-logger` by supplying
+pairs of :<level> <function> as additional arguments.  These will be used
+instead of the default `clojure.tools.logging` functions. The default mapping
+is:
 
-      {:info  (fn [x] (clojure.tools.logging/info x))
-       :debug (fn [x] (clojure.tools.logging/debug x))
-       :error (fn [x] (clojure.tools.logging/error x))
-       :warn  (fn [x] (clojure.tools.logging/warn x))}
-       
-Replace these functions with whatever logging facility you'd like to
-use. Each function should take a string and log it at that log level.
+      :info  (fn [x] (clojure.tools.logging/info x))
+      :debug (fn [x] (clojure.tools.logging/debug x))
+      :error (fn [x] (clojure.tools.logging/error x))
+      :warn  (fn [x] (clojure.tools.logging/warn x))
+
+Replace these functions with whatever logging facility you'd like to use. Each
+function should take a string and log it at that log level.  For example, if
+you want to use a different function to log info and debug messages, you could
+call `wrap-with-logger` like this:
+
+      (wrap-with-logger my-app
+        :info my-info-logger
+        :debug my-debug-logger)
 
 
 What Gets Logged

--- a/README.md
+++ b/README.md
@@ -14,13 +14,16 @@ Usage
 
 In your `project.clj`, add the following dependency:
 
+```clojure
     [ring.middleware.logger "0.5.0"]
+```
 
 
 Then, just add the middleware to your stack. It comes preconfigured with
 reasonable defaults, which append ANSI colorized log messages on each
 request to whatever logger is in use by clojure.tools.logging.
 
+```clojure
     (ns foo
       (:require [ring.adapter.jetty     :as jetty]
                 [ring.middleware.logger :as logger]))
@@ -31,6 +34,7 @@ request to whatever logger is in use by clojure.tools.logging.
           :body "Hello world!"})
 
     (jetty/run-jetty (logger/wrap-with-logger my-ring-app) {:port 8080})
+```
 
 
 If you'd prefer plaintext logging without the ANSI colors, use
@@ -41,23 +45,27 @@ Custom Logger Backend
 -----------------------
 
 You can supply a custom logger functions to `wrap-with-logger` by supplying
-pairs of :<level> <function> as additional arguments.  These will be used
+pairs of `:level custom-logger-fn` as additional arguments.  These will be used
 instead of the default `clojure.tools.logging` functions. The default mapping
 is:
 
+```clojure
       :info  (fn [x] (clojure.tools.logging/info x))
       :debug (fn [x] (clojure.tools.logging/debug x))
       :error (fn [x] (clojure.tools.logging/error x))
       :warn  (fn [x] (clojure.tools.logging/warn x))
+```
 
 Replace these functions with whatever logging facility you'd like to use. Each
 function should take a string and log it at that log level.  For example, if
 you want to use a different function to log info and debug messages, you could
 call `wrap-with-logger` like this:
 
+```clojure
       (wrap-with-logger my-app
         :info my-info-logger
         :debug my-debug-logger)
+```
 
 
 What Gets Logged


### PR DESCRIPTION
The docs currently make it seem (to me, at least) that
`wrap-with-logger` accepts a single map argument to define custom loggers,
when in fact, it accepts a variable number pairs of level keywords and logger
functions.

Here's an attempt to update the Readme to make this more clear, if you like it
:)
