### PR TITLE
Add ignore-uri option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ call `wrap-with-logger` like this:
 ```clojure
       (wrap-with-logger my-ring-app
         :info (fn [x] (my.custom.logging/info x))
-        :debug (fn [x] (my.custom.logging/debug x)))
+        :debug (fn [x] (my.custom.logging/™debug x)))
 ```
 
 
@@ -85,7 +85,18 @@ request can be cross-referenced. These IDs are printed in random ANSI colors
 by default, for easy visual correlation of log messages while reading
 a log file.
 
+Ignore URI's
+------------
 
+You can specify an optional list of uri that the logger should ignore. This can ideally
+be used to ignore service healthz checks, favicon.io requests etc. Here is a sample
+ignore-uris config:
+
+```clojure
+   (wrap-with-logger my-ring-app
+     ; leading "/" are optional
+     :ignore-uris ["/healthz" "favicon" "statz"])
+```
 
 License
 -------

--- a/src/ring/middleware/logger.clj
+++ b/src/ring/middleware/logger.clj
@@ -155,7 +155,7 @@ infrastructure, unless status is >= 500, in which case they are sent as errors."
 
           (when-not ignore?
             (pre-logger options
-              request))
+                        request))
 
           (let [response (handler request)
                 finish (System/currentTimeMillis)
@@ -163,9 +163,9 @@ infrastructure, unless status is >= 500, in which case they are sent as errors."
 
             (when-not ignore?
               (post-logger options
-                request
-                response
-                total))
+                           request
+                           response
+                           total))
 
             response)
 
@@ -173,9 +173,9 @@ infrastructure, unless status is >= 500, in which case they are sent as errors."
             (let [finish (System/currentTimeMillis)
                   total (- finish start)]
               (exception-logger options
-                request
-                t
-                total))
+                                request
+                                t
+                                total))
             (throw t)))))))
 
 (def default-options
@@ -223,3 +223,4 @@ infrastructure, unless status is >= 500, in which case they are sent as errors."
     (let [body ^String (slurp (:body request))]
       ((:info logger-fns)  " -- Raw request body: '" body "'")
       (handler (assoc request :body (java.io.ByteArrayInputStream. (.getBytes body)))))))
+    

--- a/src/ring/middleware/logger.clj
+++ b/src/ring/middleware/logger.clj
@@ -6,8 +6,9 @@
    [clojure.java.io]
    [onelog.core :as log]
    [clj-logging-config.log4j :as log-config]
-   [clansi.core :as ansi]))
-
+   [clansi.core :as ansi])
+  (:import
+    [java.util.regex Pattern]))
 
 
 ;; TODO: Alter this subsystem to contain a predefined map of all
@@ -15,7 +16,8 @@
 ;; are practically illegible.
 (def id-colorizations
   "Foreground / background color codes allowable for random ID colorization."
-  {:white :bg-white :black :bg-black :red :bg-red :green :bg-green :blue :bg-blue :yellow :bg-yellow :magenta :bg-magenta :cyan :bg-cyan} )
+  {:white :bg-white :black :bg-black :red :bg-red :green :bg-green :blue :bg-blue
+   :yellow :bg-yellow :magenta :bg-magenta :cyan :bg-cyan} )
 
 (def id-foreground-colors (keys id-colorizations))
 (def id-colorization-count (count id-foreground-colors))
@@ -42,14 +44,14 @@
   [{:keys [info debug] :as options}
    {:keys [request-method uri remote-addr query-string params] :as req}]
   (info (str (ansi/style "Starting " :cyan)
-             request-method " " 
-             uri (if query-string (str "?" query-string)) 
+             request-method " "
+             uri (if query-string (str "?" query-string))
              " for " remote-addr
              " " (dissoc (:headers req) "authorization"))) ;; log headers, but don't log username/password, if any
 
-  (debug (str "Request details: " (select-keys req [:server-port :server-name :remote-addr :uri 
-                                                       :query-string :scheme :request-method 
-                                                       :conent-type :content-length :character-encoding])))
+  (debug (str "Request details: " (select-keys req [:server-port :server-name :remote-addr :uri
+                                                    :query-string :scheme :request-method
+                                                    :conent-type :content-length :character-encoding])))
   (if params
     (info (str "  \\ - - - -  Params: " params))))
 
@@ -62,7 +64,7 @@ infrastructure, unless status is >= 500, in which case they are sent as errors."
 
   [{:keys [error info] :as options}
    {:keys [request-method uri remote-addr query-string] :as req}
-   {:keys [status] :as resp}  
+   {:keys [status] :as resp}
    totaltime]
 
   (log/trace "[ring] Sending response: " resp)
@@ -75,17 +77,17 @@ infrastructure, unless status is >= 500, in which case they are sent as errors."
                                (>= totaltime 500)   [:yellow]
                                :else :default))
                        (catch Exception e (or totaltime "??")))
-        
+
         colorstatus (try (apply ansi/style
                                 (str status)
                                 (cond
-                                 (< status 300)  [:default] 
-                                 (>= status 500) [:bright :red] 
-                                 (>= status 400) [:red] 
+                                 (< status 300)  [:default]
+                                 (>= status 500) [:bright :red]
+                                 (>= status 400) [:red]
                                  :else           [:yellow]))
                          (catch Exception e (or status "???")))
         log-message (str (ansi/style "Finished " :cyan)
-                         request-method " " 
+                         request-method " "
                          uri  (if query-string (str "?" query-string))
                          " for " remote-addr
                          " in (" colortime " ms)"
@@ -100,71 +102,81 @@ infrastructure, unless status is >= 500, in which case they are sent as errors."
       (error log-message)
       (info  log-message))))
 
-
-
 (defn- exception-logger
   [{:keys [error] :as options}
    {:keys [request-method uri remote-addr] :as request}
    throwable totaltime]
-  (error (str (ansi/style "Uncaught exception processing request:" :bright :red)  " for " remote-addr " in (" totaltime " ms) - request was: " request))
+  (error (str (ansi/style "Uncaught exception processing request:" :bright :red)
+              (format " for %s in (%s  ms) - request was: %s" remote-addr  totaltime request)))
   (error (log/throwable throwable)))
 
+(defn- ignore-uri?
+  [{:keys [ignore-uris] :as options}
+   {:keys [uri] :as request}]
+  (some #(re-find % uri) ignore-uris))
 
 (defn- make-logger-middleware
-  [handler & {:keys [pre-logger post-logger exception-logger] :as options}]
+  [handler & {:keys [pre-logger post-logger exception-logger ignore-uris] :as options}]
   "Adds logging for requests using the given logger functions.
 
-The convenience function (wrap-with-logger) calls this function with
-default loggers. Use (make-logger) directly if you want to supply your own
-logger functions.
+  The convenience function (wrap-with-logger) calls this function with
+  default loggers. Use (make-logger) directly if you want to supply your own
+  logger functions.
 
-Each request is assigned a random hex id, to allow logged events
-relevant to a particular request to be correlated. This is exposed as
-a log4j Nested Diagnostic Context (NDC). Add a %x to your log format
-string to log it. (OneLog already includes the necessary %x by
-default.)
+  Each request is assigned a random hex id, to allow logged events
+  relevant to a particular request to be correlated. This is exposed as
+  a log4j Nested Diagnostic Context (NDC). Add a %x to your log format
+  string to log it. (OneLog already includes the necessary %x by
+  default.)
 
-The pre-logger function is called before the handler is invoked, and
-receives the request as an argument.
+  The pre-logger function is called before the handler is invoked, and
+  receives the request as an argument.
 
-The post-logger function is called after the response is generated,
-and receives the request, the response, and the total time taken by the handler as arguments
+  The post-logger function is called after the response is generated,
+  and receives the request, the response, and the total time taken by the handler as arguments
 
-The exception-logger function is called in a (catch) clause, if an
-exception is thrown during the handler's run. It receives the request,
-the Throwable that was thrown, and the total time taken to that
-point. It re-throws the exception after logging it, so that other
-middleware has a chance to do something with it.
-"
-;; Long ago, originally based on
-;; https://gist.github.com/kognate/noir.incubator/blob/master/src/noir.incubator/middleware.clj
+  The exception-logger function is called in a (catch) clause, if an
+  exception is thrown during the handler's run. It receives the request,
+  the Throwable that was thrown, and the total time taken to that
+  point. It re-throws the exception after logging it, so that other
+  middleware has a chance to do something with it.
+
+  The ignore-uris list represents a list of uri's to which requests do not need to be
+  logged . This can typically by used for service healthz and statz endpoints
+  "
+  ;; Long ago, originally based on
+  ;; https://gist.github.com/kognate/noir.incubator/blob/master/src/noir.incubator/middleware.clj
+  (log/info "Options " options)
   (fn [request]
-    (let [start (System/currentTimeMillis)]
+    (let [start (System/currentTimeMillis)
+          ignore? (ignore-uri? options request)]
       (log-config/with-logging-context (format-id (rand-int 0xffff))
         (try
-          (pre-logger options
-                      request)
+
+          (when-not ignore?
+            (pre-logger options
+              request))
 
           (let [response (handler request)
                 finish (System/currentTimeMillis)
-                total  (- finish start)]
+                total (- finish start)]
 
-            (post-logger options
-                         request
-                         response
-                         total)
+            (when-not ignore?
+              (post-logger options
+                request
+                response
+                total))
 
             response)
 
           (catch Throwable t
             (let [finish (System/currentTimeMillis)
-                  total  (- finish start)]
+                  total (- finish start)]
               (exception-logger options
-                                request
-                                t
-                                total))
+                request
+                t
+                total))
             (throw t)))))))
-
 
 (def default-options
   "Default logging functions."
@@ -175,8 +187,18 @@ middleware has a chance to do something with it.
    :pre-logger pre-logger
    :post-logger post-logger
    :exception-logger exception-logger
+   :ignore-uris []
    })
 
+(defn- compile-ignore-uris
+  [options]
+  (->> options
+      :ignore-uris
+      ; strip all leading "/"
+      (map #(clojure.string/replace-first % #"/" ""))
+      ; compile all strings into regex patterns
+      (map #(re-pattern (format "[/.]*%s[/.]*" %)))
+      (assoc options :ignore-uris)))
 
 (defn wrap-with-logger
   "Returns a Ring middleware handler which uses the prepackaged color loggers.
@@ -185,17 +207,15 @@ middleware has a chance to do something with it.
    Values are functions that accept a string argument and log it at that level.
    Uses OneLog to log if none are supplied."
   ([handler & {:as options}]
-     (mapply (partial make-logger-middleware handler)
-                             (merge default-options
-                                    options))))
-
-
+     (let [options (merge default-options options)]
+       (mapply (partial make-logger-middleware handler)
+               (compile-ignore-uris options)))))
 
 (defn wrap-with-body-logger
   "Returns a Ring middleware handler that will log the bodies of any
   incoming requests by reading them into memory, logging them, and
   then putting them back into a new InputStream for other handlers to
-  read. 
+  read.
 
   This is inefficient, and should only be used for debugging."
   [handler logger-fns]


### PR DESCRIPTION
- Allows the user to configure certain paths that need not be logged
- Ideally should be used for service health check and stats endpoints
  which are called frequently
- Avoids log bloat (keep that splunk $$ bill down!)
