### PR TITLE
Remove reference to non-existent function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ request to whatever logger is in use by clojure.tools.logging.
 ```
 
 
-If you'd prefer plaintext logging without the ANSI colors, use
-`wrap-with-plaintext-logger` instead.
-
-
 Logging only certain requests
 -----------------------------
 


### PR DESCRIPTION
The referenced function, `wrap-with-plaintext-logger` does not seem to be present in the current version of the code.  This is a minor update to the documentation to reflect that fact.
