### PR TITLE
make-logger-middleware should be public, as per docs.

### DIFF
--- a/src/ring/middleware/logger.clj
+++ b/src/ring/middleware/logger.clj
@@ -110,7 +110,7 @@ infrastructure, unless status is >= 500, in which case they are sent as errors."
   (error (log/throwable throwable)))
 
 
-(defn- make-logger-middleware
+(defn make-logger-middleware
   [handler & {:keys [pre-logger post-logger exception-logger] :as options}]
   "Adds logging for requests using the given logger functions.
 


### PR DESCRIPTION
The documentation string says that the function can be called directly
to avoid the default configuration. This wasn't possible before because
the function was private to the ns.
