### PR TITLE
Decouple a bit from onelog, add tools.logging and timbre implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Usage
 In your `project.clj`, add the following dependency:
 
 ```clojure
-    [ring.middleware.logger "0.5.0"]
+    [ring.middleware.logger "0.5.0" :exclusions [com.taoensso/timbre onelog]]
 ```
 
 
@@ -37,6 +37,63 @@ request to whatever logger is in use by clojure.tools.logging.
     (jetty/run-jetty (logger/wrap-with-logger my-ring-app) {:port 8080})
 ```
 
+Usage with onelog
+-----------------
+
+In your `project.clj`, add the following dependency:
+
+```clojure
+    [ring.middleware.logger "0.5.0" :exclusions [com.taoensso/timbre]]
+```
+
+
+Add the middleware to your stack, using the onelog implementation. It's similar to
+using the default tools.logging implementation, but passing the onelog impl when
+adding the middleware:
+
+```clojure
+    (ns foo
+      (:require [ring.adapter.jetty     :as jetty]
+                [ring.middleware.logger :as logger]
+                [ring.middleware.logger.onelog :refer [make-onelog-logger]))
+
+    (defn my-ring-app [request]
+         {:status 200
+          :headers {"Content-Type" "text/html"}
+          :body "Hello world!"})
+
+    (jetty/run-jetty (logger/wrap-with-logger my-ring-app
+                                              :logger-impl (make-onelog-logger)
+                     {:port 8080})
+
+Usage with timbre
+-----------------
+
+In your `project.clj`, add the following dependency:
+
+```clojure
+    [ring.middleware.logger "0.5.0" :exclusions [onelog]]
+```
+
+
+Add the middleware to your stack, using the timbre implementation. It's similar to
+using the default tools.logging implementation, but passing the timbre impl when
+adding the middleware:
+
+```clojure
+    (ns foo
+      (:require [ring.adapter.jetty     :as jetty]
+                [ring.middleware.logger :as logger]
+                [ring.middleware.logger.timbre :refer [make-timbre-logger]))
+
+    (defn my-ring-app [request]
+         {:status 200
+          :headers {"Content-Type" "text/html"}
+          :body "Hello world!"})
+
+    (jetty/run-jetty (logger/wrap-with-logger my-ring-app
+                                              :logger-impl (make-timbre-logger)
+                     {:port 8080})
 
 Logging only certain requests
 -----------------------------

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,6 @@
   :description "Ring middleware to log each request."
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojars.pjlegato/clansi "1.3.0"]
-                 [org.tobereplaced/mapply "1.0.0"]
                  [org.clojure/tools.logging "0.3.1" :scope "provided"]
                  [onelog "0.4.5" :scope "provided"]
                  [com.taoensso/timbre "4.1.1" :scope "provided"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring.middleware.logger "0.5.1-SNAPSHOT"
+(defproject ring.middleware.logger "0.6.0-SNAPSHOT"
   :description "Ring middleware to log each request."
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojars.pjlegato/clansi "1.3.0"]

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Ring middleware to log each request."
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojars.pjlegato/clansi "1.3.0"]
-                 [org.clojure/tools.logging "0.3.1" :scope "provided"]
+                 [org.clojure/tools.logging "0.3.1"]
                  [onelog "0.4.5" :scope "provided"]
                  [com.taoensso/timbre "4.1.1" :scope "provided"]]
   :profiles {:dev {:dependencies [[ring/ring-mock "0.2.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojars.pjlegato/clansi "1.3.0"]
                  [org.tobereplaced/mapply "1.0.0"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [onelog "0.4.5"]]
+                 [org.clojure/tools.logging "0.3.1" :scope "provided"]
+                 [onelog "0.4.5" :scope "provided"]
+                 [com.taoensso/timbre "4.1.1" :scope "provided"]]
   :profiles {:dev {:dependencies [[ring/ring-mock "0.2.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,8 @@
 (defproject ring.middleware.logger "0.5.1-SNAPSHOT"
   :description "Ring middleware to log each request."
-  :dependencies [[org.clojure/clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojars.pjlegato/clansi "1.3.0"]
                  [org.tobereplaced/mapply "1.0.0"]
-                 [onelog "0.4.5"]
-                 ])
+                 [org.clojure/tools.logging "0.3.1"]
+                 [onelog "0.4.5"]]
+  :profiles {:dev {:dependencies [[ring/ring-mock "0.2.0"]]}})

--- a/src/ring/middleware/logger.clj
+++ b/src/ring/middleware/logger.clj
@@ -2,7 +2,6 @@
   "Ring middleware that logs information about each request to a given
   set of generic logging functions."
   (:require
-   [org.tobereplaced (mapply :refer [mapply])]
    [clojure.java.io]
    [ring.middleware.logger.tools-logging :refer [make-tools-logging-logger]]
    [ring.middleware.logger.protocols :refer [Logger error error-with-ex info warn debug trace add-extra-middleware]]

--- a/src/ring/middleware/logger/log4j.clj
+++ b/src/ring/middleware/logger/log4j.clj
@@ -1,0 +1,16 @@
+(ns ring.middleware.logger.log4j
+  (:require [onelog.core :as log]
+            [ring.middleware.logger.protocols :refer [Logger]]))
+
+(defrecord OnelogLogger []
+  Logger
+
+  (error [_ x] (log/error x))
+  (error [_ ex x] (log/error (log/throwable ex) x))
+  (info [_ x] (log/info x)) 
+  (warn [_ x] (log/warn x)) 
+  (debug [_ x] (log/debug x))
+  (trace [_ x] (log/trace x)))
+
+(defn make-onelog-logger []
+  (OnelogLogger.))

--- a/src/ring/middleware/logger/log4j.clj
+++ b/src/ring/middleware/logger/log4j.clj
@@ -1,9 +1,41 @@
 (ns ring.middleware.logger.log4j
-  (:require [onelog.core :as log]
+  (:require [clansi.core :as ansi]
+            [clj-logging-config.log4j :as log-config]
+            [onelog.core :as log]
             [ring.middleware.logger.protocols :refer [Logger]]))
+
+;; TODO: Alter this subsystem to contain a predefined map of all
+;; acceptable fg/bg combinations, since some (e.g. white on yellow)
+;; are practically illegible.
+(def id-colorizations
+  "Foreground / background color codes allowable for random ID colorization."
+  {:white :bg-white :black :bg-black :red :bg-red :green :bg-green :blue :bg-blue :yellow :bg-yellow :magenta :bg-magenta :cyan :bg-cyan} )
+
+(def id-foreground-colors (keys id-colorizations))
+(def id-colorization-count (count id-foreground-colors))
+
+(defn- get-colorization
+  [id]
+  "Returns a consistent colorization for the given id; that is, the
+  same ID produces the same color pattern. The colorization will have
+  distinct foreground and background colors."
+  (let [foreground (nth id-foreground-colors (mod id id-colorization-count))
+        background-possibilities (vals (dissoc id-colorizations foreground))
+        background (nth background-possibilities (mod id (- id-colorization-count 1)))]
+    [foreground background]))
+
+(defn- format-id [id]
+  "Returns a standard colorized, printable representation of a request id."
+  (if id
+    (apply ansi/style (format "%04x" id) [:bright] (get-colorization id))))
 
 (defrecord OnelogLogger []
   Logger
+
+  (add-extra-middleware [_ handler]
+    (fn [request]
+      (log-config/with-logging-context (format-id (rand-int 0xffff))
+        (handler request))))
 
   (error [_ x] (log/error x))
   (error [_ ex x] (log/error (log/throwable ex) x))

--- a/src/ring/middleware/logger/protocols.clj
+++ b/src/ring/middleware/logger/protocols.clj
@@ -1,8 +1,15 @@
 (ns ring.middleware.logger.protocols)
 
 (defprotocol Logger
+  (add-extra-middleware [_ f])
   (error [_ x] [_ ex x])
   (info [_ x])
   (warn [_ x])
   (debug [_ x])
   (trace [_ x]))
+
+(extend-type Object
+  Logger
+  (add-extra-middleware [_ handler]
+    ; returns handler untouched
+    handler))

--- a/src/ring/middleware/logger/protocols.clj
+++ b/src/ring/middleware/logger/protocols.clj
@@ -1,0 +1,8 @@
+(ns ring.middleware.logger.protocols)
+
+(defprotocol Logger
+  (error [_ x] [_ ex x])
+  (info [_ x])
+  (warn [_ x])
+  (debug [_ x])
+  (trace [_ x]))

--- a/src/ring/middleware/logger/protocols.clj
+++ b/src/ring/middleware/logger/protocols.clj
@@ -1,15 +1,10 @@
 (ns ring.middleware.logger.protocols)
 
 (defprotocol Logger
-  (add-extra-middleware [_ f])
-  (error [_ x] [_ ex x])
+  (add-extra-middleware [_ handler])
+  (error [_ x])
+  (error-with-ex [_ ex x])
   (info [_ x])
   (warn [_ x])
   (debug [_ x])
   (trace [_ x]))
-
-(extend-type Object
-  Logger
-  (add-extra-middleware [_ handler]
-    ; returns handler untouched
-    handler))

--- a/src/ring/middleware/logger/timbre.clj
+++ b/src/ring/middleware/logger/timbre.clj
@@ -1,0 +1,18 @@
+(ns ring.middleware.logger.timbre
+  (:require [taoensso.timbre :as log]
+            [ring.middleware.logger.protocols :refer [Logger]]))
+
+(defrecord TimbreLogger []
+  Logger
+
+  (add-extra-middleware [_ handler] handler)
+
+  (error [_ x] (log/error x))
+  (error-with-ex [_ ex x] (log/error ex x))
+  (info [_ x] (log/info x))
+  (warn [_ x] (log/warn x)) 
+  (debug [_ x] (log/debug x))
+  (trace [_ x] (log/trace x)))
+
+(defn make-timbre-logger []
+  (TimbreLogger.))

--- a/src/ring/middleware/logger/tools_logging.clj
+++ b/src/ring/middleware/logger/tools_logging.clj
@@ -1,0 +1,17 @@
+(ns ring.middleware.logger.tools-logging
+  (:require [clojure.tools.logging :as log]
+            [ring.middleware.logger.protocols :refer [Logger]]))
+
+(defrecord ToolsLoggingLogger []
+  Logger
+
+  (add-extra-middleware [_ handler] handler)
+  (error [_ x] (log/error x))
+  (error-with-ex [_ ex x] (log/error ex x))
+  (info [_ x] (log/info x))
+  (warn [_ x] (log/warn x)) 
+  (debug [_ x] (log/debug x))
+  (trace [_ x] (log/trace x)))
+
+(defn make-tools-logging-logger []
+  (ToolsLoggingLogger.))

--- a/test/ring/middleware/logger/timbre_test.clj
+++ b/test/ring/middleware/logger/timbre_test.clj
@@ -1,0 +1,82 @@
+(ns ring.middleware.logger.timbre-test
+  (:require [clojure.test :refer :all]
+            [taoensso.timbre :as timbre]
+            [ring.middleware.logger.timbre :refer [make-timbre-logger]]
+            [ring.middleware.logger :refer [wrap-with-logger]]
+            [ring.mock.request :as mock]))
+
+(def ^{:dynamic true} *entries* (atom []))
+
+(defn atom-appender
+  [a]
+  {:enabled?   true
+   :async?     false
+   :min-level  nil
+   :rate-limit nil
+   :output-fn  :inherit
+   :fn
+   (fn [{:keys [level ?ns-str output-fn] :as data}]
+     (swap! a conj [?ns-str level nil (output-fn data)]))})
+
+(defn make-timbre-test-config []
+  (merge timbre/example-config
+         {:level :trace
+          :appenders {:atom (atom-appender *entries*)}}))
+
+(use-fixtures :once
+  (fn [f]
+    (timbre/with-config (make-timbre-test-config)
+      (f))))
+
+(use-fixtures :each
+  (fn [f]
+    (f)
+    (swap! *entries* (constantly []))))
+
+(deftest basic-ok-request-logging
+  (let [handler (-> (fn [req]
+                      {:status 200
+                       :body "ok"
+                       :headers {:a "header in the response"}})
+                    (wrap-with-logger :logger-impl (make-timbre-logger)))]
+    (handler (mock/request :get "/doc/10"))
+    (let [entries @*entries*]
+      (is (= [:info :debug :trace :info] (map second entries)))
+      (is (re-find #"Starting.*get /doc/10 for localhost"
+                   (-> entries first (nth 3))))
+      (is (re-find #":headers \{:a \"header in the response\"\}"
+                   (-> entries (nth 2) (nth 3))))   
+      (is (re-find #"Finished.*get /doc/10 for localhost in \(\d+ ms\) Status:.*200"
+                   (-> entries last (nth 3)))))))
+
+(deftest basic-error-request-logging
+  (let [handler (-> (fn [req]
+                      {:status 500
+                       :body "Oh noes!"
+                       :headers {:a "header in the response"}})
+                    (wrap-with-logger :logger-impl (make-timbre-logger)))]
+    (handler (mock/request :get "/doc/10"))
+    (let [entries @*entries*]
+      (is (= [:info :debug :trace :error] (map second entries)))
+      (is (re-find #"Starting.*get /doc/10 for localhost"
+                   (-> entries first (nth 3))))
+      (is (re-find #":headers \{:a \"header in the response\"\}"
+                   (-> entries (nth 2) (nth 3))))   
+      (is (re-find #"Finished.*get /doc/10 for localhost in \(\d+ ms\) Status:.*500"
+                   (-> entries last (nth 3)))))))
+
+(deftest basic-error-with-exception-request-logging
+  (let [handler (-> (fn [req]
+                      (throw (Exception. "I'm a handler that throws!")))
+                    (wrap-with-logger :logger-impl (make-timbre-logger)))]
+    (is (thrown-with-msg? Exception #"handler that throws"
+                          (handler (mock/request :get "/doc/10"))))
+    (let [entries @*entries*]
+      (is (= [:info :debug :error :error] (map second entries)))
+      (is (re-find #"Starting.*get /doc/10 for localhost"
+                   (-> entries first (nth 3))))
+      (is (re-find #"Uncaught exception processing request.*for localhost in \(\d+ ms\)"
+                   (-> entries (nth 2) (nth 3))))
+      (is (not (re-find #"Finished" (-> entries last (nth 3)))))
+      (is (re-find #"I'm a handler that throws\!"
+                   (-> entries (nth 3) (nth 3)))))))

--- a/test/ring/middleware/logger/tools_logging_test.clj
+++ b/test/ring/middleware/logger/tools_logging_test.clj
@@ -1,0 +1,61 @@
+(ns ring.middleware.logger.tools-logging-test
+  (:require [clojure.test :refer :all]
+            [clojure.tools.logging :refer :all]
+            [clojure.tools.logging.impl :as impl]
+            [ring.middleware.logger :refer [wrap-with-logger]]
+            [ring.mock.request :as mock]))
+
+(def ^{:dynamic true} *entries* (atom []))
+
+(defn test-factory [enabled-set]
+  (reify impl/LoggerFactory
+    (name [_] "test factory")
+    (get-logger [_ log-ns]
+      (reify impl/Logger
+        (enabled? [_ level] (contains? enabled-set level))
+        (write! [_ lvl ex msg]
+          (swap! *entries* conj [(str log-ns) lvl ex msg]))))))
+
+(use-fixtures :once
+  (fn [f]
+    (binding [*logger-factory*
+              (test-factory #{:trace :debug :info :warn :error :fatal})]
+      (f))))
+
+(use-fixtures :each
+  (fn [f]
+    (f)
+    (swap! *entries* (constantly []))))
+
+(deftest basic-ok-request-logging
+  (let [handler (-> (fn [req]
+                      {:status 200
+                       :body "ok"
+                       :headers {:a "header in the response"}})
+                    (wrap-with-logger))]
+    (handler (mock/request :get "/doc/10"))
+    (let [entries @*entries*]
+      (is (= [:info :debug :trace :info] (map second entries)))
+      (is (re-find #"Starting.*get /doc/10 for localhost"
+                   (-> entries first (nth 3))))
+      (is (re-find #":headers \{:a \"header in the response\"\}"
+                   (-> entries (nth 2) (nth 3))))   
+      (is (re-find #"Finished.*get /doc/10 for localhost in \(\d+ ms\) Status:.*200"
+                   (-> entries last (nth 3)))))))
+
+(deftest basic-error-request-logging
+  (let [handler (-> (fn [req]
+                      (println "handler")
+                      {:status 500
+                       :body "Oh noes!"
+                       :headers {:a "header in the response"}})
+                    (wrap-with-logger))]
+    (handler (mock/request :get "/doc/10"))
+    (let [entries @*entries*]
+      (is (= [:info :debug :trace :error] (map second entries)))
+      (is (re-find #"Starting.*get /doc/10 for localhost"
+                   (-> entries first (nth 3))))
+      (is (re-find #":headers \{:a \"header in the response\"\}"
+                   (-> entries (nth 2) (nth 3))))   
+      (is (re-find #"Finished.*get /doc/10 for localhost in \(\d+ ms\) Status:.*500"
+                   (-> entries last (nth 3)))))))


### PR DESCRIPTION
I wanted to use the library on a project that is using `taoensso/timbre` but I couldn't, because of conflicting dependencies versions but also because it was not enought to supply alternative `#{:error :debug :info}` functions: For example, `trace` was being called directly, there was no way to pass a custom implementation.
