### PR TITLE
Bump onelog version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Usage
 In your `project.clj`, add the following dependency:
 
 ```clojure
-    [ring.middleware.logger "0.5.0"]
+    [ring.middleware.logger "0.5.1"]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Usage
 In your `project.clj`, add the following dependency:
 
 ```clojure
-    [ring.middleware.logger "0.5.1"]
+    [ring.middleware.logger "0.5.2"]
 ```
 
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(defproject ring.middleware.logger "0.5.1-SNAPSHOT"
+(defproject ring.middleware.logger "0.5.2"
   :description "Ring middleware to log each request."
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojars.pjlegato/clansi "1.3.0"]
                  [org.tobereplaced/mapply "1.0.0"]
-                 [onelog "0.4.5"]
+                 [onelog "0.5.1"]
                  ])


### PR DESCRIPTION
@pjlegato once you push `onelog` to Clojars can we bump this version as well?

This is to allow these libraries to play nice in 1.9.

Thanks!
Owen